### PR TITLE
bug-fix-incorrect-shell-variables-expansion-in-documents

### DIFF
--- a/lua/typst-preview/preview.lua
+++ b/lua/typst-preview/preview.lua
@@ -87,14 +87,12 @@ local function update_total_page_number()
         output = target_pdf,
     })
     local cmd = table.concat(typst_cmd, " ")
-    cmd = cmd .. " << EOF\n" .. utils.get_buf_content(state.code.buf) .. "\nEOF\n"
+    cmd = cmd .. " << 'EOF'\n" .. utils.get_buf_content(state.code.buf) .. "\nEOF\n"
     cmd = cmd .. "pdfinfo " .. target_pdf .. " | grep Pages | awk '{print $2}'"
     local res = vim.system({ vim.o.shell, vim.o.shellcmdflag, cmd }):wait()
     local new_page_number = tonumber(res.stdout)
     if not new_page_number then
-        log.warn(
-            "(preview) failed to get page number:\n" .. res.stderr
-        )
+        log.warn("(preview) failed to get page number:\n" .. res.stderr)
         return
     end
     state.pages.total = new_page_number


### PR DESCRIPTION
# Problem Description

The plugin incorrectly counted pages for documents containing mathematical expressions with $ symbols, particularly when these expressions resembled shell variables. For example, a 30-page document would show only 24 pages, preventing navigation to pages beyond that limit.

# Root Cause Analysis

The issue was in the update_total_page_number() function in preview.lua:90. The function constructs a shell command using an unquoted heredoc to pass document content to typst compile:
```
cmd = cmd .. " << EOF\n" .. utils.get_buf_content(state.code.buf) .. "\nEOF\n"
```
This creates a shell command like:
typst compile -f pdf - output.pdf << EOF
[document content with $ symbols]
EOF
pdfinfo output.pdf | grep Pages | awk '{print $2}'

The problem: Unquoted heredocs perform shell variable expansion. When the document contains mathematical expressions or patterns that look like shell variables, the shell corrupts the content before it reaches typst compile. 
For instance, `$32 + (9 * 12) = 140$` becomes `+ (9 \times 12)` = 140$ (shell expands $32 as empty variable)

# Solution

The fix is simple but critical - use a quoted heredoc to prevent shell variable expansion:
```
cmd = cmd .. " << 'EOF'\n" .. utils.get_buf_content(state.code.buf) .. "\nEOF\n"
```
The single quotes around 'EOF' tell the shell to treat the heredoc content literally, preserving all $ symbols and mathematical expressions exactly as written.